### PR TITLE
Add GitHub Value project to MainProjects section

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -120,6 +120,33 @@
         <img src="assets/screenshots/chrome_xebwmFt39a.png" alt="Github Actions Usage Report" aria-label="Github Actions Usage Report" />
       </a>
     </div>
+
+    <div class="project-container">
+      <div class="project-info">
+        <h2>GitHub Value</h2>
+        <mat-card class="mat-elevation-z8">
+          GitHub Value is a free and open-source application designed to help measure the adoption, value, and impact of GitHub features.</mat-card>
+        <div class="links">
+
+          <a mat-raised-button color="primary" href="https://oauth.gvm-chart.com/copilot"
+            target="_blank" rel="noopener">
+            <mat-icon>preview</mat-icon>
+            Demo
+          </a>
+
+          <a mat-raised-button color="primary"
+            href="https://github.com/austenstone/github-value"
+            target="_blank" rel="noopener">
+            <mat-icon>code</mat-icon>
+            Source
+          </a>
+        </div>
+      </div>
+      <a class="project-image elev-hover" href="https://oauth.gvm-chart.com/copilot" target="_blank"
+        rel="noopener">
+        <img src="https://github.com/user-attachments/assets/09c494cd-fbdb-4b8e-9cb3-696371e9487a" alt="GitHub Value" aria-label="GitHub Value" />
+      </a>
+    </div>
   </section>
 
   <section>


### PR DESCRIPTION
This PR resolves issue #29 by adding the GitHub Value project to the MainProjects section.

**Changes made:**
- Added a new project container with the GitHub Value information
- Included project title, description, demo link, source link, and image as specified
- Maintained consistent styling with other project entries

The GitHub Value project is now displayed in the MainProjects section with the following details:
- Title: GitHub Value
- Description: GitHub Value is a free and open-source application designed to help measure the adoption, value, and impact of GitHub features.
- Demo link: https://oauth.gvm-chart.com/copilot
- Source link: https://github.com/austenstone/github-value
- Image: Used the provided image URL from GitHub user attachments

Closes #29