### PR TITLE
Add GitHub Value project to MainProjects section

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: 22.x
 
@@ -35,7 +35,7 @@ jobs:
         run: npm run build
 
       - name: Archive artifacts 💽
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
@@ -46,16 +46,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: 22.x
 
@@ -76,9 +76,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: ⬇️ Download austen-stone artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: dist
 

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -35,6 +35,32 @@
       <!-- <div id="main-projects-title"></div> -->
       MainProjects
     </h1>
+    <div class="project-container">
+      <div class="project-info">
+        <h2>GitHub Value</h2>
+        <mat-card class="mat-elevation-z8">
+          GitHub Value is a free and open-source application designed to help measure the adoption, value, and impact of GitHub features.</mat-card>
+        <div class="links">
+          <a mat-raised-button color="primary" href="https://oauth.gvm-chart.com/copilot"
+            target="_blank" rel="noopener">
+            <mat-icon>preview</mat-icon>
+            Demo
+          </a>
+
+          <a mat-raised-button color="primary"
+            href="https://github.com/austenstone/github-value"
+            target="_blank" rel="noopener">
+            <mat-icon>code</mat-icon>
+            Source
+          </a>
+        </div>
+      </div>
+      <a class="project-image elev-hover" href="https://oauth.gvm-chart.com/copilot" target="_blank"
+        rel="noopener">
+        <img src="https://github.com/user-attachments/assets/09c494cd-fbdb-4b8e-9cb3-696371e9487a" alt="GitHub Value" aria-label="GitHub Value" />
+      </a>
+    </div>
+    
     <div class="project-container" id="github-actions">
       <!-- <div class="project-image" [style.backgroundImage]="'url(' + 'assets/screenshots/chrome_E0qv0L1q0I.jpg' + ')'"></div>-->
       <div class="project-info">
@@ -120,6 +146,7 @@
         <img src="assets/screenshots/chrome_xebwmFt39a.png" alt="Github Actions Usage Report" aria-label="Github Actions Usage Report" />
       </a>
     </div>
+
   </section>
 
   <section>


### PR DESCRIPTION
This PR implements the changes requested in issue #29:

- Added the GitHub Value project to the MainProjects section
- Placed it as the first project in the section
- Added demo and source code links
- Used the provided project image

Closes #29