### PR TITLE
Add Giscus comments integration to Docusaurus blog

### DIFF
--- a/.github/prompts/implement-giscus-comments.prompt.md
+++ b/.github/prompts/implement-giscus-comments.prompt.md
@@ -1,0 +1,68 @@
+---
+mode: agent
+description: "A prompt to implement Giscus comments on the Docusaurus blog."
+---
+
+# Plan: Implement Giscus Comments in Docusaurus
+
+This plan outlines the steps to integrate Giscus, a comment system powered by GitHub Discussions, into your Docusaurus portfolio website. This will allow visitors to leave comments on your blog posts using their GitHub accounts, with the comments stored directly in your site's GitHub repository.
+
+## Requirements
+
+- The comment system must be free and integrate with the existing GitHub repository.
+- Users must be able to log in and comment using their GitHub accounts.
+- Comments must be tied to specific blog post URLs.
+- The comment section's theme should automatically adapt to the website's light and dark modes.
+- The feature should be enabled on a per-post basis via front matter.
+
+## Implementation Steps
+
+### 1. Configure GitHub Repository
+
+- **Enable Discussions:** In your `austenstone/portfolio` GitHub repository settings, enable the "Discussions" feature.
+- **Create a Category:** Create a new discussion category specifically for blog comments (e.g., "Blog Comments") to keep them organized.
+
+### 2. Set Up Giscus
+
+- **Install Giscus App:** Go to the [Giscus website](https://giscus.app/) and install the Giscus GitHub App.
+- **Grant Repository Access:** Authorize the app to access your `austenstone/portfolio` repository.
+- **Configuration:** On the Giscus configuration page, select your repository and the newly created "Blog Comments" discussion category.
+- **Get IDs:** Copy the generated Repository ID and Category ID provided by Giscus. These will be needed for the component.
+
+### 3. Create the Giscus React Component
+
+- **Install Dependency:** Add the `@giscus/react` package to your project by running `npm install @giscus/react`.
+- **Create Component File:** Create a new file at `src/components/GiscusComponent/index.tsx`.
+- **Implement Component Logic:** In this file, create a React component that uses the `<Giscus />` component from the installed package.
+    - Pass the Repository ID and Category ID from the previous step as props.
+    - Use the `useColorMode` hook from Docusaurus to dynamically set the Giscus `theme` prop, ensuring it matches the site's current theme.
+    - Configure other Giscus settings like `mapping`, `reactionsEnabled`, etc., as required.
+
+### 4. Integrate Component into Blog Posts
+
+- **Swizzle `BlogPostItem`:** Use the Docusaurus swizzle command to create a customizable wrapper for the blog post component:
+    ```bash
+    npm run swizzle @docusaurus/theme-classic BlogPostItem -- --wrap
+    ```
+- **Modify Swizzled Component:** Edit the newly created file at `src/theme/BlogPostItem/index.js` (or `index.tsx`).
+    - Import your `GiscusComponent`.
+    - Use the `useBlogPost()` hook to access the current post's metadata and determine if it's a blog post page (`isBlogPostPage`).
+    - Add logic to conditionally render the `GiscusComponent` only when `isBlogPostPage` is `true` and the post's front matter contains `enableComments: true`.
+
+### 5. Enable Comments in Content
+
+- **Update a Blog Post:** Select a blog post to test with, for example, `blog/2025-06-26-welcome-to-portfolio.md`.
+- **Add Front Matter:** Add the field `enableComments: true` to the front matter of the selected blog post file.
+
+## Testing
+
+1.  **Local Development:**
+    - Start the development server using `npm run start`.
+    - Navigate to the blog post where comments have been enabled and verify that the Giscus widget loads correctly.
+    - Navigate to a different blog post without the `enableComments` flag and confirm the widget does not appear.
+    - Post a test comment to ensure it appears on the page and in the corresponding GitHub Discussion.
+2.  **Theme Verification:**
+    - Toggle the website between light and dark modes to ensure the Giscus component's theme updates accordingly.
+3.  **Production Build:**
+    - Run `npm run build` to create a production build of the site.
+    - Serve the build locally (e.g., using `npm run serve`) and repeat the verification steps to ensure everything works as expected in the production environment.

--- a/blog/2025-06-26-welcome-to-portfolio.md
+++ b/blog/2025-06-26-welcome-to-portfolio.md
@@ -5,6 +5,7 @@ tags: [website, development]
 image: /img/docusaurus/undraw_docusaurus_react.svg
 date: 2025-06-26
 description: A brief introduction to my new portfolio website built with Docusaurus, showcasing my projects and blog.
+enableComments: true
 ---
 
 I've migrated my portfolio from Angular to [Docusaurus](https://docusaurus.io/docs) to focus more on content and less on maintenance.

--- a/blog/2025-06-30-github-copilot-agent-mcp/2025-06-30-github-copilot-agent-mcp.mdx
+++ b/blog/2025-06-30-github-copilot-agent-mcp/2025-06-30-github-copilot-agent-mcp.mdx
@@ -5,6 +5,7 @@ tags: [github-copilot, ai, development]
 image: https://code.visualstudio.com/assets/blogs/2025/02/24/diagram.png
 date: 2025-06-30
 description: How I'm using GitHub Copilot agent mode with MCP to supercharge my development workflow through structured planning, implementation, and testing.
+enableComments: true
 ---
 
 import CodeBlock from '@theme/CodeBlock';

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@docusaurus/core": "3.8.1",
         "@docusaurus/preset-classic": "3.8.1",
         "@docusaurus/theme-mermaid": "^3.8.1",
+        "@giscus/react": "^3.1.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "highlight.js": "^11.11.1",
@@ -3968,6 +3969,18 @@
         "node": ">=18.0"
       }
     },
+    "node_modules/@giscus/react": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@giscus/react/-/react-3.1.0.tgz",
+      "integrity": "sha512-0TCO2TvL43+oOdyVVGHDItwxD1UMKP2ZYpT6gXmhFOqfAJtZxTzJ9hkn34iAF/b6YzyJ4Um89QIt9z/ajmAEeg==",
+      "dependencies": {
+        "giscus": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18 || ^19",
+        "react-dom": "^16 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -4109,6 +4122,21 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "license": "MIT"
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
+      "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.0.tgz",
+      "integrity": "sha512-L2qyoZSQClcBmq0qajBVbhYEcG6iK0XfLn66ifLe/RfC0/ihpc+pl0Wdn8bJ8o+hj38cG0fGXRgSS20MuXn7qA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
+      }
     },
     "node_modules/@mdx-js/mdx": {
       "version": "3.1.0",
@@ -5221,8 +5249,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "2.0.11",
@@ -9237,6 +9264,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/giscus": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/giscus/-/giscus-1.6.0.tgz",
+      "integrity": "sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lit": "^3.2.1"
+      }
+    },
     "node_modules/github-slugger": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
@@ -10816,6 +10852,37 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
+    },
+    "node_modules/lit": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.0.tgz",
+      "integrity": "sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.0.tgz",
+      "integrity": "sha512-MGrXJVAI5x+Bfth/pU9Kst1iWID6GHDLEzFEnyULB/sFiRLgkd8NPK/PeeXxktA3T6EIIaq8U3KcbTU5XFcP2Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.0.tgz",
+      "integrity": "sha512-RHoswrFAxY2d8Cf2mm4OZ1DgzCoBKUKSPvA1fhtSELxUERq2aQQ2h05pO9j81gS1o7RIRJ+CePLogfyahwmynw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/loader-runner": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@docusaurus/core": "3.8.1",
     "@docusaurus/preset-classic": "3.8.1",
     "@docusaurus/theme-mermaid": "^3.8.1",
+    "@giscus/react": "^3.1.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "highlight.js": "^11.11.1",

--- a/src/components/GiscusComponent/index.tsx
+++ b/src/components/GiscusComponent/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Giscus from '@giscus/react';
+import { useColorMode } from '@docusaurus/theme-common';
+
+export default function GiscusComponent(): React.ReactElement {
+  const { colorMode } = useColorMode();
+
+  return (
+    <div style={{ marginTop: '2rem' }}>
+      <Giscus
+        id="comments"
+        repo="austenstone/portfolio"
+        repoId="MDEwOlJlcG9zaXRvcnkyNTUwNjU0MjI=" // Replace with your actual repo ID from https://giscus.app/
+        category="General"
+        categoryId="DIC_kwDODzP9Ts4CsRld" // Replace with your actual category ID from https://giscus.app/
+        mapping="pathname"
+        term="Welcome to giscus!"
+        reactionsEnabled="1"
+        emitMetadata="0"
+        inputPosition="top"
+        theme={colorMode === 'dark' ? 'dark' : 'light'}
+        lang="en"
+        loading="lazy"
+        strict="0"
+      />
+    </div>
+  );
+}

--- a/src/theme/BlogPostItem/index.tsx
+++ b/src/theme/BlogPostItem/index.tsx
@@ -1,0 +1,26 @@
+import React, {type ReactNode} from 'react';
+import BlogPostItem from '@theme-original/BlogPostItem';
+import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
+import GiscusComponent from '@site/src/components/GiscusComponent';
+import type BlogPostItemType from '@theme/BlogPostItem';
+import type {WrapperProps} from '@docusaurus/types';
+
+type Props = WrapperProps<typeof BlogPostItemType>;
+
+export default function BlogPostItemWrapper(props: Props): ReactNode {
+  const {metadata, isBlogPostPage} = useBlogPost();
+  const {frontMatter} = metadata;
+  const {enableComments} = frontMatter as {enableComments?: boolean};
+
+  return (
+    <>
+      <BlogPostItem {...props} />
+      {enableComments && isBlogPostPage && (
+        <div style={{ marginTop: '2rem' }}>
+          <h2>Comments</h2>
+          <GiscusComponent />
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
Integrate Giscus comments into the Docusaurus blog, allowing users to comment using their GitHub accounts. Enable comments on a per-post basis through front matter and ensure the comment section adapts to light and dark themes.