### PR TITLE
Group Dependabot security updates so they stop bypassing the PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,12 @@ updates:
     # produces an unresolvable peer range, which is what left the standalone
     # typescript and @eslint/js PRs red and stuck.
     groups:
+      # A group omitting `applies-to` covers version updates only, so security
+      # updates were opening one PR per package and ignoring the limit above.
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
       docusaurus:
         patterns:
           - "@docusaurus/*"
@@ -44,6 +50,10 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
       actions:
         patterns:
           - "*"


### PR DESCRIPTION
Follow-up to #51. The `dependabot.yml` I shipped there had a gap I only found once Dependabot actually ran against it.

## What happened

After #51 merged, Dependabot opened **14 simultaneous PRs** — against an `open-pull-requests-limit` of **5**:

```
dompurify  eslint  fast-uri  flatted  follow-redirects  launch-editor
nanoid  node-forge  postcss  shell-quote  svgo
webpack-dev-server  websocket-driver  ws
```

Every one of them edits `package-lock.json`, so they all conflict with each other. Merging any one makes the other thirteen `DIRTY`.

## Why the limit and the groups were both ignored

Dependabot group rules take an `applies-to` key that **defaults to `version-updates`**. Every group in the file omitted it, so security updates matched no group at all — and ungrouped security updates also don't count against `open-pull-requests-limit`.

So the config was only ever governing half the traffic. The half that actually fires on a schedule was grouped; the half that fires off advisories was not.

```yaml
groups:
  security:
    applies-to: security-updates   # <- this was missing
    patterns: ["*"]
```

Added to both the npm and `github-actions` ecosystems.

## Worth separating two numbers that look like the same number

`npm audit` reports **25** vulnerabilities. The repo has **5** open Dependabot alerts:

| severity | package | scope |
|---|---|---|
| high | `image-size` ×2 | runtime |
| high | `serialize-javascript` | runtime |
| medium | `serialize-javascript` | runtime |
| medium | `uuid` | runtime |

`npm audit` counts every *path* through the dependency graph, so one vulnerable package reached three ways counts three times. Dependabot dedupes to the package. **5 is the real number**, and all five are transitive through `@docusaurus/*`.

None of the 14 PRs above touched any of those five packages — zero overlap. They were routine version bumps of indirect dependencies, which is exactly the traffic that should have been grouped and capped.

`image-size` remains genuinely unfixable from here: `@docusaurus/core` pins `^2.0.2` and `2.0.2` is the newest published version. That's upstream's to fix.

## Verification

`.github/dependabot.yml` parses, and both ecosystems resolve their group sets:

```
npm:             ['security', 'docusaurus', 'eslint', 'react', 'unified', 'minor-and-patch']
github-actions:  ['actions-security', 'actions']
```

Config-only change — no code, no lockfile.
